### PR TITLE
Optimize compute shader (~55% faster)

### DIFF
--- a/src/main/java/com/gpuExtended/rendering/passes/MainPassLegacy.java
+++ b/src/main/java/com/gpuExtended/rendering/passes/MainPassLegacy.java
@@ -218,14 +218,12 @@ public class MainPassLegacy implements IPassBase {
         vertexBufferContext.normalBuffer.clear();
         vertexBufferContext.flagsBuffer.clear();
 
-        computeBufferContext.smallModelBuffer.clear();
-        computeBufferContext.largeModelBuffer.clear();
         computeBufferContext.unsortedModelBuffer.clear();
+        computeBufferContext.ClearSortedModelBuffer();
 
-        computeBufferContext.numSmallModels = 0;
-        computeBufferContext.numLargeModels = 0;
+
+        computeBufferContext.ResetSortedModelBufferCounts();
         computeBufferContext.numUnsortedModels = 0;
-
         computeBufferContext.totalDynamicVertices = 0;
         computeBufferContext.totalDynamicUvs = 0;
 
@@ -290,8 +288,7 @@ public class MainPassLegacy implements IPassBase {
 
         vCtx.FlipBuffers();
         cCtx.unsortedModelBuffer.flip();
-        cCtx.smallModelBuffer.flip();
-        cCtx.largeModelBuffer.flip();
+        cCtx.FlipSortedModelBuffers();
 
         IntBuffer vertexBuffer = vCtx.vertexBuffer.getBuffer();
         FloatBuffer uvBuffer = vCtx.uvBuffer.getBuffer();
@@ -299,13 +296,10 @@ public class MainPassLegacy implements IPassBase {
         IntBuffer flagsBuffer = vCtx.flagsBuffer.getBuffer();
 
         IntBuffer modelBufferUnordered = cCtx.unsortedModelBuffer.getBuffer();
-        IntBuffer modelBufferSmall = cCtx.smallModelBuffer.getBuffer();
-        IntBuffer modelBufferLarge = cCtx.largeModelBuffer.getBuffer();
 
         // compute sorting buffers
         plugin.updateBuffer(cCtx.tmpUnsortedModelBuffer, GL_ARRAY_BUFFER, modelBufferUnordered, GL_DYNAMIC_DRAW);
-        plugin.updateBuffer(cCtx.tmpSmallModelBuffer, GL_ARRAY_BUFFER, modelBufferSmall, GL_DYNAMIC_DRAW);
-        plugin.updateBuffer(cCtx.tmpLargeModelBuffer, GL_ARRAY_BUFFER, modelBufferLarge, GL_DYNAMIC_DRAW);
+        cCtx.UpdateSortedModelBuffers(plugin);
 
         // dynamic model buffers
         plugin.updateBuffer(cCtx.dynamicVertexInBuffer, GL_ARRAY_BUFFER, vertexBuffer, GL_DYNAMIC_DRAW);
@@ -321,8 +315,15 @@ public class MainPassLegacy implements IPassBase {
         plugin.updateBuffer(cCtx.flagsOutBuffer, GL_ARRAY_BUFFER, size, GL_STREAM_DRAW);
 
         DispatchSortingCompute(cCtx.tmpUnsortedModelBuffer, cCtx.numUnsortedModels, plugin.shaders.unorderedComputeShader.id());
-        DispatchSortingCompute(cCtx.tmpSmallModelBuffer, cCtx.numSmallModels, plugin.shaders.smallOrderedComputeShader.id());
-        DispatchSortingCompute(cCtx.tmpLargeModelBuffer, cCtx.numLargeModels, plugin.shaders.largeOrderedComputeShader.id());
+
+        DispatchSortingCompute(cCtx.sortedModelGlBuffers[0], cCtx.numSortedModels[0], plugin.shaders.orderedComputeShader64.id());
+        DispatchSortingCompute(cCtx.sortedModelGlBuffers[1], cCtx.numSortedModels[1], plugin.shaders.orderedComputeShader128.id());
+        DispatchSortingCompute(cCtx.sortedModelGlBuffers[2], cCtx.numSortedModels[2], plugin.shaders.orderedComputeShader256.id());
+        DispatchSortingCompute(cCtx.sortedModelGlBuffers[3], cCtx.numSortedModels[3], plugin.shaders.orderedComputeShader512.id());
+        DispatchSortingCompute(cCtx.sortedModelGlBuffers[4], cCtx.numSortedModels[4], plugin.shaders.orderedComputeShader1024.id());
+        DispatchSortingCompute(cCtx.sortedModelGlBuffers[5], cCtx.numSortedModels[5], plugin.shaders.orderedComputeShader2048.id());
+        DispatchSortingCompute(cCtx.sortedModelGlBuffers[6], cCtx.numSortedModels[6], plugin.shaders.orderedComputeShader4096.id());
+        DispatchSortingCompute(cCtx.sortedModelGlBuffers[7], cCtx.numSortedModels[7], plugin.shaders.orderedComputeShaderMAX_TRIANGLES.id());
 
         plugin.performanceOverlay.EndTimer(PerformanceOverlay.TimerType.DRAW_MAIN_PASS);
     }
@@ -445,6 +446,7 @@ public class MainPassLegacy implements IPassBase {
         assert model == renderable;
 
         if(CalculateModelBoundsAndClickbox(projection, model, orientation, x, y, z, hash)) {
+            if (offsetModel.getFaceCount() <= 0) return;
             int tileX = (x / LOCAL_TILE_SIZE) + SCENE_OFFSET;
             int tileY = (z / LOCAL_TILE_SIZE) + SCENE_OFFSET;
 
@@ -453,7 +455,7 @@ public class MainPassLegacy implements IPassBase {
             int flags = GetModelPackedFlags(hash, model, offsetModel, orientation);
             int exFlags = GetExFlags(hash, tileX, tileY, z, false);
 
-            GpuIntBuffer b = GetCorrectModelBufferForTriangleCount(faceCount);
+            GpuIntBuffer b = computeBufferContext.GetCorrectModelBufferForTriangleCount(faceCount);
 
             b.ensureCapacity(12);
             IntBuffer buffer = b.getBuffer();
@@ -486,6 +488,7 @@ public class MainPassLegacy implements IPassBase {
         int tileY = (z / LOCAL_TILE_SIZE) + SCENE_OFFSET;
 
         if(CalculateModelBoundsAndClickbox(projection, model, orientation, x, y, z, hash)) {
+            if (model.getFaceCount() <= 0) return;
             int flags = GetModelPackedFlags(hash, model, offsetModel, orientation);
             int exFlags = GetExFlags(hash, tileX, tileY, z, true);
             boolean hasUv = model.getFaceTextures() != null;
@@ -493,7 +496,7 @@ public class MainPassLegacy implements IPassBase {
 
             int vertexCount = plugin.sceneUploader.PushDynamicModel(model, 0, isNPC, vertexBufferContext.vertexBuffer, vertexBufferContext.uvBuffer, vertexBufferContext.normalBuffer, vertexBufferContext.flagsBuffer);
 
-            GpuIntBuffer b = GetCorrectModelBufferForTriangleCount(vertexCount / 3);
+            GpuIntBuffer b = computeBufferContext.GetCorrectModelBufferForTriangleCount(vertexCount / 3);
             b.ensureCapacity(12);
             IntBuffer buffer = b.getBuffer();
             buffer.put(computeBufferContext.totalDynamicVertices);
@@ -594,29 +597,12 @@ public class MainPassLegacy implements IPassBase {
         return -1;
     }
 
-    private GpuIntBuffer GetCorrectModelBufferForTriangleCount(int triangles) {
-        // Returns the appropriate model buffer based on the number of triangles.
-        if (triangles <= SMALL_TRIANGLE_COUNT)
-        {
-            computeBufferContext.numSmallModels++;
-            return computeBufferContext.smallModelBuffer;
-        }
-        else
-        {
-            computeBufferContext.numLargeModels++;
-            return computeBufferContext.largeModelBuffer;
-        }
-    }
-
     private void DispatchSortingCompute(GLBuffer modelBuffer, int numModels, int computeShader) {
+        if (numModels <= 0)  return;
         Uniforms uniforms = plugin.uniforms;
-        ShaderHandler shaders = plugin.shaders;
 
         // Bind uniforms for compute shaders | TODO:: this may not need to be done every frame. Also, move uniform buffers to uniform wrapper or something
-        glUniformBlockBinding(shaders.smallOrderedComputeShader.id(), uniforms.GetUniforms(shaders.smallOrderedComputeShader.id()).BlockSmall, CAMERA_BUFFER_BINDING_ID);
-        glBindBufferBase(GL_UNIFORM_BUFFER, CAMERA_BUFFER_BINDING_ID, uniforms.glCameraUniformBuffer.glBufferId);
-
-        glUniformBlockBinding(shaders.largeOrderedComputeShader.id(), uniforms.GetUniforms(shaders.largeOrderedComputeShader.id()).BlockLarge, CAMERA_BUFFER_BINDING_ID);
+        glUniformBlockBinding(computeShader, uniforms.GetUniforms(computeShader).BlockSmall, CAMERA_BUFFER_BINDING_ID);
         glBindBufferBase(GL_UNIFORM_BUFFER, CAMERA_BUFFER_BINDING_ID, uniforms.glCameraUniformBuffer.glBufferId);
 
         glUseProgram(computeShader);

--- a/src/main/java/com/gpuExtended/shader/ShaderHandler.java
+++ b/src/main/java/com/gpuExtended/shader/ShaderHandler.java
@@ -67,10 +67,21 @@ public class ShaderHandler {
             .add(GL_VERTEX_SHADER, "vert_postProcess.glsl")
             .add(GL_FRAGMENT_SHADER, "bloom_prefilter.glsl");
 
-    public Shader largeOrderedComputeShader = new Shader()
+    public Shader orderedComputeShader64 = new Shader()
             .add(GL_COMPUTE_SHADER, "comp.glsl");
-
-    public Shader smallOrderedComputeShader = new Shader()
+    public Shader orderedComputeShader128 = new Shader()
+            .add(GL_COMPUTE_SHADER, "comp.glsl");
+    public Shader orderedComputeShader256 = new Shader()
+            .add(GL_COMPUTE_SHADER, "comp.glsl");
+    public Shader orderedComputeShader512 = new Shader()
+            .add(GL_COMPUTE_SHADER, "comp.glsl");
+    public Shader orderedComputeShader1024 = new Shader()
+            .add(GL_COMPUTE_SHADER, "comp.glsl");
+    public Shader orderedComputeShader2048 = new Shader()
+            .add(GL_COMPUTE_SHADER, "comp.glsl");
+    public Shader orderedComputeShader4096 = new Shader()
+            .add(GL_COMPUTE_SHADER, "comp.glsl");
+    public Shader orderedComputeShaderMAX_TRIANGLES = new Shader()
             .add(GL_COMPUTE_SHADER, "comp.glsl");
 
     public Shader unorderedComputeShader = new Shader()
@@ -167,8 +178,15 @@ public class ShaderHandler {
         switch (computeMode)
         {
             case OPENGL:
-                largeOrderedComputeShader.compile(createTemplate(1024, 6), compiledShaders);
-                smallOrderedComputeShader.compile(createTemplate(512, 1), compiledShaders);
+                orderedComputeShader64.compile(createTemplate(64, 1), compiledShaders);
+                orderedComputeShader128.compile(createTemplate(128, 1), compiledShaders);
+                orderedComputeShader256.compile(createTemplate(256, 1), compiledShaders);
+                orderedComputeShader512.compile(createTemplate(512, 1), compiledShaders);
+                orderedComputeShader1024.compile(createTemplate(1024, 1), compiledShaders);
+                orderedComputeShader2048.compile(createTemplate(1024, 2), compiledShaders);
+                orderedComputeShader4096.compile(createTemplate(1024, 4), compiledShaders);
+                orderedComputeShaderMAX_TRIANGLES.compile(createTemplate(1024, 6), compiledShaders);
+
                 unorderedComputeShader.compile(template, compiledShaders);
                 lightBinningComputeShader.compile(template, compiledShaders);
                 break;

--- a/src/main/java/com/gpuExtended/util/contexts/ComputeBufferContext.java
+++ b/src/main/java/com/gpuExtended/util/contexts/ComputeBufferContext.java
@@ -1,12 +1,12 @@
 package com.gpuExtended.util.contexts;
 
+import com.gpuExtended.GpuExtendedPlugin;
 import com.gpuExtended.opengl.GLBuffer;
 import com.gpuExtended.util.GpuIntBuffer;
 import lombok.extern.slf4j.Slf4j;
-import org.lwjgl.opengl.GL;
 
-import static org.lwjgl.opengl.GL15C.glGenBuffers;
-import static org.lwjgl.opengl.GL43C.GL_BUFFER;
+import static com.gpuExtended.util.constants.Variables.MAX_TRIANGLE;
+import static org.lwjgl.opengl.GL15C.*;
 import static org.lwjgl.opengl.GL43C.glObjectLabel;
 
 @Slf4j
@@ -31,16 +31,14 @@ public class ComputeBufferContext {
 
     // Buffers used for model sorting
     public GLBuffer tmpUnsortedModelBuffer;
-    public GLBuffer tmpSmallModelBuffer;
-    public GLBuffer tmpLargeModelBuffer;
 
     public GpuIntBuffer unsortedModelBuffer;
-    public GpuIntBuffer smallModelBuffer;
-    public GpuIntBuffer largeModelBuffer;
+
+    public GpuIntBuffer[] sortedModelIntBuffers;
+    public GLBuffer[] sortedModelGlBuffers;
+    public int[] numSortedModels;
 
     public int numUnsortedModels;
-    public int numSmallModels;
-    public int numLargeModels;
 
     public int totalVertices;
     public int totalDynamicVertices;
@@ -49,8 +47,6 @@ public class ComputeBufferContext {
     public ComputeBufferContext() {
 
         this.unsortedModelBuffer = new GpuIntBuffer();
-        this.smallModelBuffer = new GpuIntBuffer();
-        this.largeModelBuffer = new GpuIntBuffer();
 
         // Output
         this.vertexOutBuffer = new GLBuffer("vertex out buffer");
@@ -72,8 +68,6 @@ public class ComputeBufferContext {
 
         // Model Sorting buffers
         this.tmpUnsortedModelBuffer = new GLBuffer("unsorted model buffer");
-        this.tmpSmallModelBuffer = new GLBuffer("small model buffer");
-        this.tmpLargeModelBuffer = new GLBuffer("large model buffer");
 
         InitGLBuffer(this.vertexOutBuffer);
         InitGLBuffer(this.uvOutBuffer);
@@ -91,8 +85,73 @@ public class ComputeBufferContext {
         InitGLBuffer(this.dynamicFlagsBuffer);
 
         InitGLBuffer(this.tmpUnsortedModelBuffer);
-        InitGLBuffer(this.tmpSmallModelBuffer);
-        InitGLBuffer(this.tmpLargeModelBuffer);
+
+        InitSortedModelBuffers();
+    }
+
+    public void ResetSortedModelBufferCounts() {
+        for(int i = 0; i < 8; i++) {
+            this.numSortedModels[i] = 0;
+        }
+    }
+
+    public void ClearSortedModelBuffer() {
+        for(int i = 0; i < 8; i++) {
+            this.sortedModelIntBuffers[i].clear();
+        }
+    }
+
+    private void InitSortedModelBuffers() {
+        // Sizes are powers of two starting at 64
+        // 64 chosen as minimum because nvidia typically has 32 warp size and AMD has 64, so max between these two is a good default
+        // 64
+        // 128
+        // 256
+        // 512
+        // 1024
+        // 2048
+        // 4096
+        // MAX_TRIANGLE = 1024*6 = 6144
+        // 8 different sizes
+        this.sortedModelIntBuffers = new GpuIntBuffer[8];
+        this.sortedModelGlBuffers = new GLBuffer[8];
+        this.numSortedModels = new int[8];
+        for(int i = 0; i < 8; i++) {
+            int size = 64 << i;
+            this.sortedModelGlBuffers[i] = new GLBuffer("sorted models size=" + size);
+            InitGLBuffer(this.sortedModelGlBuffers[i]);
+            this.sortedModelIntBuffers[i] = new GpuIntBuffer();
+            this.numSortedModels[i] = 0;
+        }
+    }
+
+    public void FlipSortedModelBuffers() {
+        for(int i = 0; i < 8; i++) {
+            this.sortedModelIntBuffers[i].flip();
+        }
+    }
+
+    public void UpdateSortedModelBuffers(GpuExtendedPlugin plugin) {
+        for(int i = 0; i < 8; i++) {
+            plugin.updateBuffer(this.sortedModelGlBuffers[i], GL_ARRAY_BUFFER, this.sortedModelIntBuffers[i].getBuffer(), GL_DYNAMIC_DRAW);
+        }
+    }
+
+    public static int log2(int bits) // returns 0 for bits=0
+    {
+        double x = Math.log(bits) / Math.log(2);
+        return (int)Math.ceil(x);
+    }
+
+    public GpuIntBuffer GetCorrectModelBufferForTriangleCount(int triangles) {
+        assert triangles > 0 : "Triangle count was " + triangles;
+        assert triangles <= MAX_TRIANGLE : "Triangle count was greater than MAX_TRIANGLE=" + MAX_TRIANGLE + " triangles=" + triangles;
+        int log = log2(triangles);
+        if (log < 6) log = 6; // minimum 64. 6 == log2(64)
+
+        this.numSortedModels[log-6]++;
+        GpuIntBuffer buffer = this.sortedModelIntBuffers[log-6];
+        return buffer;
     }
 
     private void InitGLBuffer(GLBuffer glBuffer) {
@@ -102,8 +161,6 @@ public class ComputeBufferContext {
 
     public void Clear() {
         this.numUnsortedModels = 0;
-        this.numSmallModels = 0;
-        this.numLargeModels = 0;
 
         this.totalVertices = 0;
     }
@@ -125,16 +182,15 @@ public class ComputeBufferContext {
         this.dynamicFlagsBuffer = null;
 
         this.tmpUnsortedModelBuffer = null;
-        this.tmpSmallModelBuffer = null;
-        this.tmpLargeModelBuffer = null;
 
         this.unsortedModelBuffer = null;
-        this.smallModelBuffer = null;
-        this.largeModelBuffer = null;
 
         this.numUnsortedModels = 0;
-        this.numSmallModels = 0;
-        this.numLargeModels = 0;
+        this.ResetSortedModelBufferCounts();
+
+        this.numSortedModels = null;
+        this.sortedModelGlBuffers = null;
+        this.sortedModelIntBuffers = null;
 
         this.totalVertices = 0;
     }

--- a/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
@@ -2,12 +2,15 @@
 #include "THREAD_COUNT"
 #include "FACES_PER_THREAD"
 
-shared int totalNum[12];       // number of faces with a given priority
-shared int totalDistance[12];  // sum of distances to faces of a given priority
+shared int totalNum12;
+shared int totalDistance12;
+shared int totalNum34;
+shared int totalDistance34;
+shared int totalNum68;
+shared int totalDistance68;
+shared int min10;                                         // minimum distance to a face of priority 10
 
 shared int totalMappedNum[18];  // number of faces with a given adjusted priority
-
-shared int min10;                                         // minimum distance to a face of priority 10
 shared int renderPris[THREAD_COUNT * FACES_PER_THREAD];  // packed distance and face id
 
 #include "shaders/glsl/constants.glsl"
@@ -118,41 +121,40 @@ void main() {
 
   if (localId == 0) {
     min10 = 6000;
-    for (int i = 0; i < 12; ++i) {
-      totalNum[i] = 0;
-      totalDistance[i] = 0;
-    }
+    totalNum12 = 0;
+    totalDistance12 = 0;
+    totalNum34 = 0;
+    totalDistance34 = 0;
+    totalNum68 = 0;
+    totalDistance68 = 0;
     for (int i = 0; i < 18; ++i) {
       totalMappedNum[i] = 0;
     }
   }
 
-  // TODO: recalc distance/prio to reduce register usage?
-  int prio[FACES_PER_THREAD];
   int dis[FACES_PER_THREAD];
   Vertex vA[FACES_PER_THREAD];
   Vertex vB[FACES_PER_THREAD];
   Vertex vC[FACES_PER_THREAD];
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    get_face(localId + i, minfo, cameraYaw, cameraPitch, prio[i], dis[i], vA[i], vB[i], vC[i]);
+    get_face(localId + i, minfo, cameraYaw, cameraPitch, dis[i], vA[i], vB[i], vC[i]);
   }
 
   memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    add_face_prio_distance(localId + i, minfo, vA[i], vB[i], vC[i], prio[i], dis[i], pos);
+    add_face_prio_distance(localId + i, minfo, vA[i], vB[i], vC[i], dis[i], pos);
   }
 
   memoryBarrierShared();
   barrier();
 
-  // TODO: recalc prioAdj/idx to reduce register usage?
   int prioAdj[FACES_PER_THREAD];
   int idx[FACES_PER_THREAD];
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    idx[i] = map_face_priority(localId + i, minfo, prio[i], dis[i], prioAdj[i]);
+    idx[i] = map_face_priority(localId + i, minfo, dis[i], vA[i], prioAdj[i]);
   }
 
   memoryBarrierShared();
@@ -166,12 +168,10 @@ void main() {
   barrier();
 
   int outputOffsets[FACES_PER_THREAD];
-  int thisRenderPriority[FACES_PER_THREAD];
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     calculate_output_offsets(localId + i, minfo, prioAdj[i], dis[i],
                              vA[i], vB[i], vC[i],
-                             outputOffsets[i], thisRenderPriority[i]);
-
+                             outputOffsets[i]);
   }
 
   memoryBarrierShared();
@@ -181,8 +181,7 @@ void main() {
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     int size = minfo.size;
 
-    if ((localId+i) < size) { // TODO: when moving this remove the + i
-      //int localIdFromRenderPriority = (~(thisRenderPriority[i] & 0xffff)) & 0xffff;
+    if ((localId+i) < size) {
       renderPris[outputOffsets[i]] = int(localId+i);
     }
   }
@@ -195,55 +194,76 @@ void main() {
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     int size = minfo.size;
 
-    if ((localId+i) < size) { // TODO: when moving this remove the + i
-      whoSendsMeVertices[i] = renderPris[localId+i]; // TODO: when moving this remove the + i
+    if ((localId+i) < size) {
+      whoSendsMeVertices[i] = renderPris[localId+i];
     } else {
       // For out of bounds vertices, we make them look at their own index to remove the if check for size each time
       // The index into shared memory is in bounds, it's just not going to have any valid data
-      whoSendsMeVertices[i] = int(localId) + i; // TODO: when moving this remove the + i
+      whoSendsMeVertices[i] = int(localId) + i;
     }
   }
 
   memoryBarrierShared();
   barrier();
 
-  // TODO: gather and shuffle one vertex at a time to reduce register usage
+  // TODO: Does re-reading vA/vB/vC help?
+  // Shuffle vertices from threads who've already read them to threads who share the same output index
+  // This way the thread who read verts[i] writes to outverts[i] making the writes coalesced
   shuffle_vertex(int(localId), vA, whoSendsMeVertices);
   shuffle_vertex(int(localId), vB, whoSendsMeVertices);
   shuffle_vertex(int(localId), vC, whoSendsMeVertices);
 
-  memoryBarrierShared();
-  barrier();
-
-  vec4 texA[FACES_PER_THREAD];
-  vec4 texB[FACES_PER_THREAD];
-  vec4 texC[FACES_PER_THREAD];
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     output_vertices_and_flags(localId + i, minfo, vA[i], vB[i], vC[i]);
-    gather_texture_attribute(localId + i, minfo, texA[i], texB[i], texC[i]);
   }
 
-  shuffle_vec4(int(localId), texA, whoSendsMeVertices);
-  shuffle_vec4(int(localId), texB, whoSendsMeVertices);
-  shuffle_vec4(int(localId), texC, whoSendsMeVertices);
-
-  memoryBarrierShared();
-  barrier();
-
-  vec4 normalA[FACES_PER_THREAD];
-  vec4 normalB[FACES_PER_THREAD];
-  vec4 normalC[FACES_PER_THREAD];
+  // Same for textures/normals, but we do it one component at a time to reduce register usage
+  // Unable to do the same for vertices because we need to read the 3 vertices at the start to calculate distance.
+  vec4 tex[FACES_PER_THREAD];
+  // a
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    output_uvs(localId + i, minfo, texA[i], texB[i], texC[i]);
-    gather_normal_attribute(localId + i, minfo, normalA[i], normalB[i], normalC[i]);
+    gather_texture_attribute(localId + i, minfo, 0, tex[i]);
   }
-  shuffle_vec4(int(localId), normalA, whoSendsMeVertices);
-  shuffle_vec4(int(localId), normalB, whoSendsMeVertices);
-  shuffle_vec4(int(localId), normalC, whoSendsMeVertices);
-  memoryBarrierShared();
-  barrier();
+  shuffle_vec4(int(localId), tex, whoSendsMeVertices);
+  //b
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    output_uv(localId + i, minfo, 0, tex[i]);
+    gather_texture_attribute(localId + i, minfo, 1, tex[i]);
+  }
+  shuffle_vec4(int(localId), tex, whoSendsMeVertices);
+  //c
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    output_uv(localId + i, minfo, 1, tex[i]);
+    gather_texture_attribute(localId + i, minfo, 2, tex[i]);
+  }
+  shuffle_vec4(int(localId), tex, whoSendsMeVertices);
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    output_uv(localId + i, minfo, 2, tex[i]);
+  }
+
+
+  vec4 normal[FACES_PER_THREAD];
+  //a
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    gather_normal_attribute(localId + i, minfo, 0, normal[i]);
+  }
+  shuffle_vec4(int(localId), normal, whoSendsMeVertices);
+
+  //b
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    output_normal(localId + i, minfo, 0, normal[i]);
+    gather_normal_attribute(localId + i, minfo, 1, normal[i]);
+  }
+  shuffle_vec4(int(localId), normal, whoSendsMeVertices);
+
+  //c
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    output_normal(localId + i, minfo, 1, normal[i]);
+    gather_normal_attribute(localId + i, minfo, 2, normal[i]);
+  }
+  shuffle_vec4(int(localId), normal, whoSendsMeVertices);
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    output_normals(localId + i, minfo, normalA[i], normalB[i], normalC[i]);
+    output_normal(localId + i, minfo, 2, normal[i]);
   }
 }

--- a/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
@@ -206,7 +206,6 @@ void main() {
   memoryBarrierShared();
   barrier();
 
-  // TODO: Does re-reading vA/vB/vC help?
   // Shuffle vertices from threads who've already read them to threads who share the same output index
   // This way the thread who read verts[i] writes to outverts[i] making the writes coalesced
   shuffle_vertex(int(localId), vA, whoSendsMeVertices);

--- a/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
@@ -64,6 +64,52 @@ void shuffle_vertex(int localId, inout Vertex v[FACES_PER_THREAD], in int whoSen
   barrier();
 }
 
+void shuffle_vec4(int localId, inout vec4 v[FACES_PER_THREAD], in int whoSendsMeVertices[FACES_PER_THREAD]) {
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    renderPris[localId + i] = floatBitsToInt(v[i].x);
+  }
+  memoryBarrierShared();
+  barrier();
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    v[i].x = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
+  }
+  memoryBarrierShared();
+  barrier();
+
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    renderPris[localId + i] = floatBitsToInt(v[i].y);
+  }
+  memoryBarrierShared();
+  barrier();
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    v[i].y = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
+  }
+  memoryBarrierShared();
+  barrier();
+
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    renderPris[localId + i] = floatBitsToInt(v[i].z);
+  }
+  memoryBarrierShared();
+  barrier();
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    v[i].z = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
+  }
+  memoryBarrierShared();
+  barrier();
+
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    renderPris[localId + i] = floatBitsToInt(v[i].w);
+  }
+  memoryBarrierShared();
+  barrier();
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    v[i].w = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
+  }
+  memoryBarrierShared();
+  barrier();
+}
+
 void main() {
   uint groupId = gl_WorkGroupID.x;
   uint localId = gl_LocalInvocationID.x * FACES_PER_THREAD;
@@ -117,10 +163,22 @@ void main() {
   memoryBarrierShared();
   barrier();
 
-int outputOffsets[FACES_PER_THREAD];
+  int outputOffsets[FACES_PER_THREAD];
   int thisRenderPriority[FACES_PER_THREAD];
+
+  vec4 texA[FACES_PER_THREAD];
+  vec4 texB[FACES_PER_THREAD];
+  vec4 texC[FACES_PER_THREAD];
+
+  vec4 normalA[FACES_PER_THREAD];
+  vec4 normalB[FACES_PER_THREAD];
+  vec4 normalC[FACES_PER_THREAD];
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    calculate_output_offsets(localId + i, minfo, prioAdj[i], dis[i], vA[i], vB[i], vC[i], outputOffsets[i], thisRenderPriority[i]);
+    calculate_output_offsets(localId + i, minfo, prioAdj[i], dis[i],
+                             vA[i], vB[i], vC[i],
+                             outputOffsets[i], thisRenderPriority[i]);
+    gather_texture_attribute(localId + i, minfo, texA[i], texB[i], texC[i]);
+    gather_normal_attribute(localId + i, minfo, normalA[i], normalB[i], normalC[i]);
   }
 
   memoryBarrierShared();
@@ -159,8 +217,16 @@ int outputOffsets[FACES_PER_THREAD];
   shuffle_vertex(int(localId), vA, whoSendsMeVertices);
   shuffle_vertex(int(localId), vB, whoSendsMeVertices);
   shuffle_vertex(int(localId), vC, whoSendsMeVertices);
+  memoryBarrierShared();
+  barrier();
+  shuffle_vec4(int(localId), texA, whoSendsMeVertices);
+  shuffle_vec4(int(localId), texB, whoSendsMeVertices);
+  shuffle_vec4(int(localId), texC, whoSendsMeVertices);
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    position_and_output(localId + i, minfo, vA[i], vB[i], vC[i]);
+    position_and_output(localId + i, minfo,
+                        vA[i], vB[i], vC[i],
+                        texA[i], texB[i], texC[i],
+                        normalA[i], normalB[i], normalC[i]);
   }
 }

--- a/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
@@ -25,45 +25,37 @@ void shuffle_vertex(int localId, inout Vertex v[FACES_PER_THREAD], in int whoSen
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     renderPris[localId + i] = floatBitsToInt(v[i].pos.x);
   }
-  memoryBarrierShared();
   barrier();
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     v[i].pos.x = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
   }
-  memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     renderPris[localId + i] = floatBitsToInt(v[i].pos.y);
   }
-  memoryBarrierShared();
   barrier();
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     v[i].pos.y = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
   }
-  memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     renderPris[localId + i] = floatBitsToInt(v[i].pos.z);
   }
-  memoryBarrierShared();
   barrier();
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     v[i].pos.z = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
   }
-  memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     renderPris[localId + i] = v[i].ahsl;
   }
-  memoryBarrierShared();
   barrier();
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     v[i].ahsl = renderPris[whoSendsMeVertices[i]];
   }
-  memoryBarrierShared();
   barrier();
 }
 
@@ -71,45 +63,37 @@ void shuffle_vec4(int localId, inout vec4 v[FACES_PER_THREAD], in int whoSendsMe
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     renderPris[localId + i] = floatBitsToInt(v[i].x);
   }
-  memoryBarrierShared();
   barrier();
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     v[i].x = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
   }
-  memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     renderPris[localId + i] = floatBitsToInt(v[i].y);
   }
-  memoryBarrierShared();
   barrier();
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     v[i].y = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
   }
-  memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     renderPris[localId + i] = floatBitsToInt(v[i].z);
   }
-  memoryBarrierShared();
   barrier();
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     v[i].z = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
   }
-  memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     renderPris[localId + i] = floatBitsToInt(v[i].w);
   }
-  memoryBarrierShared();
   barrier();
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     v[i].w = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
   }
-  memoryBarrierShared();
   barrier();
 }
 
@@ -141,14 +125,12 @@ void main() {
     get_face(localId + i, minfo, cameraYaw, cameraPitch, dis[i], vA[i], vB[i], vC[i]);
   }
 
-  memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     add_face_prio_distance(localId + i, minfo, vA[i], vB[i], vC[i], dis[i], pos);
   }
 
-  memoryBarrierShared();
   barrier();
 
   int prioAdj[FACES_PER_THREAD];
@@ -157,14 +139,12 @@ void main() {
     idx[i] = map_face_priority(localId + i, minfo, dis[i], vA[i], prioAdj[i]);
   }
 
-  memoryBarrierShared();
   barrier();
 
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     insert_face(localId + i, minfo, prioAdj[i], dis[i], idx[i]);
   }
 
-  memoryBarrierShared();
   barrier();
 
   int outputOffsets[FACES_PER_THREAD];
@@ -174,7 +154,6 @@ void main() {
                              outputOffsets[i]);
   }
 
-  memoryBarrierShared();
   barrier();
 
   // Scatter localIds from renderPris to the thread they're relevant to
@@ -186,7 +165,6 @@ void main() {
     }
   }
 
-  memoryBarrierShared();
   barrier();
   // Now each thread knows which localId to look up in shared memory to get info about a vertex
   // For example if thread0 has renderPri[0] == 5, this means that thread 5 tells thread 0 what vertex to write out. IE. whoSendsMeVertices[0] = 5
@@ -203,7 +181,6 @@ void main() {
     }
   }
 
-  memoryBarrierShared();
   barrier();
 
   // Shuffle vertices from threads who've already read them to threads who share the same output index

--- a/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
@@ -18,6 +18,52 @@ layout(local_size_x = THREAD_COUNT) in;
 #include "shaders/glsl/common.glsl"
 #include "shaders/glsl/priority_render.glsl"
 
+void shuffle_vertex(int localId, inout Vertex v[FACES_PER_THREAD], in int whoSendsMeVertices[FACES_PER_THREAD]) {
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    renderPris[localId + i] = floatBitsToInt(v[i].pos.x);
+  }
+  memoryBarrierShared();
+  barrier();
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    v[i].pos.x = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
+  }
+  memoryBarrierShared();
+  barrier();
+
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    renderPris[localId + i] = floatBitsToInt(v[i].pos.y);
+  }
+  memoryBarrierShared();
+  barrier();
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    v[i].pos.y = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
+  }
+  memoryBarrierShared();
+  barrier();
+
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    renderPris[localId + i] = floatBitsToInt(v[i].pos.z);
+  }
+  memoryBarrierShared();
+  barrier();
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    v[i].pos.z = intBitsToFloat(renderPris[whoSendsMeVertices[i]]);
+  }
+  memoryBarrierShared();
+  barrier();
+
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    renderPris[localId + i] = v[i].ahsl;
+  }
+  memoryBarrierShared();
+  barrier();
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    v[i].ahsl = renderPris[whoSendsMeVertices[i]];
+  }
+  memoryBarrierShared();
+  barrier();
+}
+
 void main() {
   uint groupId = gl_WorkGroupID.x;
   uint localId = gl_LocalInvocationID.x * FACES_PER_THREAD;
@@ -71,7 +117,50 @@ void main() {
   memoryBarrierShared();
   barrier();
 
+int outputOffsets[FACES_PER_THREAD];
+  int thisRenderPriority[FACES_PER_THREAD];
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    sort_and_insert(localId + i, minfo, prioAdj[i], dis[i], vA[i], vB[i], vC[i]);
+    calculate_output_offsets(localId + i, minfo, prioAdj[i], dis[i], vA[i], vB[i], vC[i], outputOffsets[i], thisRenderPriority[i]);
+  }
+
+  memoryBarrierShared();
+  barrier();
+
+  // Scatter localIds from renderPris to the thread they're relevant to
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    int size = minfo.size;
+
+    if ((localId+i) < size) { // TODO: when moving this remove the + i
+      //int localIdFromRenderPriority = (~(thisRenderPriority[i] & 0xffff)) & 0xffff;
+      renderPris[outputOffsets[i]] = int(localId+i);
+    }
+  }
+
+  memoryBarrierShared();
+  barrier();
+  // Now each thread knows which localId to look up in shared memory to get info about a vertex
+  // For example if thread0 has renderPri[0] == 5, this means that thread 5 tells thread 0 what vertex to write out. IE. whoSendsMeVertices[0] = 5
+  int whoSendsMeVertices[FACES_PER_THREAD];
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    int size = minfo.size;
+
+    if ((localId+i) < size) { // TODO: when moving this remove the + i
+      whoSendsMeVertices[i] = renderPris[localId+i]; // TODO: when moving this remove the + i
+    } else {
+      // For out of bounds vertices, we make them look at their own index to remove the if check for size each time
+      // The index into shared memory is in bounds, it's just not going to have any valid data
+      whoSendsMeVertices[i] = int(localId) + i; // TODO: when moving this remove the + i
+    }
+  }
+
+  memoryBarrierShared();
+  barrier();
+
+  shuffle_vertex(int(localId), vA, whoSendsMeVertices);
+  shuffle_vertex(int(localId), vB, whoSendsMeVertices);
+  shuffle_vertex(int(localId), vC, whoSendsMeVertices);
+
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    position_and_output(localId + i, minfo, vA[i], vB[i], vC[i]);
   }
 }

--- a/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/comp.glsl
@@ -127,6 +127,7 @@ void main() {
     }
   }
 
+  // TODO: recalc distance/prio to reduce register usage?
   int prio[FACES_PER_THREAD];
   int dis[FACES_PER_THREAD];
   Vertex vA[FACES_PER_THREAD];
@@ -147,6 +148,7 @@ void main() {
   memoryBarrierShared();
   barrier();
 
+  // TODO: recalc prioAdj/idx to reduce register usage?
   int prioAdj[FACES_PER_THREAD];
   int idx[FACES_PER_THREAD];
   for (int i = 0; i < FACES_PER_THREAD; i++) {
@@ -165,20 +167,11 @@ void main() {
 
   int outputOffsets[FACES_PER_THREAD];
   int thisRenderPriority[FACES_PER_THREAD];
-
-  vec4 texA[FACES_PER_THREAD];
-  vec4 texB[FACES_PER_THREAD];
-  vec4 texC[FACES_PER_THREAD];
-
-  vec4 normalA[FACES_PER_THREAD];
-  vec4 normalB[FACES_PER_THREAD];
-  vec4 normalC[FACES_PER_THREAD];
   for (int i = 0; i < FACES_PER_THREAD; i++) {
     calculate_output_offsets(localId + i, minfo, prioAdj[i], dis[i],
                              vA[i], vB[i], vC[i],
                              outputOffsets[i], thisRenderPriority[i]);
-    gather_texture_attribute(localId + i, minfo, texA[i], texB[i], texC[i]);
-    gather_normal_attribute(localId + i, minfo, normalA[i], normalB[i], normalC[i]);
+
   }
 
   memoryBarrierShared();
@@ -214,19 +207,43 @@ void main() {
   memoryBarrierShared();
   barrier();
 
+  // TODO: gather and shuffle one vertex at a time to reduce register usage
   shuffle_vertex(int(localId), vA, whoSendsMeVertices);
   shuffle_vertex(int(localId), vB, whoSendsMeVertices);
   shuffle_vertex(int(localId), vC, whoSendsMeVertices);
+
   memoryBarrierShared();
   barrier();
+
+  vec4 texA[FACES_PER_THREAD];
+  vec4 texB[FACES_PER_THREAD];
+  vec4 texC[FACES_PER_THREAD];
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    output_vertices_and_flags(localId + i, minfo, vA[i], vB[i], vC[i]);
+    gather_texture_attribute(localId + i, minfo, texA[i], texB[i], texC[i]);
+  }
+
   shuffle_vec4(int(localId), texA, whoSendsMeVertices);
   shuffle_vec4(int(localId), texB, whoSendsMeVertices);
   shuffle_vec4(int(localId), texC, whoSendsMeVertices);
 
+  memoryBarrierShared();
+  barrier();
+
+  vec4 normalA[FACES_PER_THREAD];
+  vec4 normalB[FACES_PER_THREAD];
+  vec4 normalC[FACES_PER_THREAD];
   for (int i = 0; i < FACES_PER_THREAD; i++) {
-    position_and_output(localId + i, minfo,
-                        vA[i], vB[i], vC[i],
-                        texA[i], texB[i], texC[i],
-                        normalA[i], normalB[i], normalC[i]);
+    output_uvs(localId + i, minfo, texA[i], texB[i], texC[i]);
+    gather_normal_attribute(localId + i, minfo, normalA[i], normalB[i], normalC[i]);
+  }
+  shuffle_vec4(int(localId), normalA, whoSendsMeVertices);
+  shuffle_vec4(int(localId), normalB, whoSendsMeVertices);
+  shuffle_vec4(int(localId), normalC, whoSendsMeVertices);
+  memoryBarrierShared();
+  barrier();
+
+  for (int i = 0; i < FACES_PER_THREAD; i++) {
+    output_normals(localId + i, minfo, normalA[i], normalB[i], normalC[i]);
   }
 }

--- a/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
@@ -64,7 +64,7 @@ int count_prio_offset(int priority) {
   return total;
 }
 
-void get_face(uint localId, modelinfo minfo, float cameraYaw, float cameraPitch, out int prio, out int dis, out Vertex o1, out Vertex o2, out Vertex o3) {
+void get_face(uint localId, modelinfo minfo, float cameraYaw, float cameraPitch, out int dis, out Vertex o1, out Vertex o2, out Vertex o3) {
   int size = minfo.size;
   int offset = minfo.offset;
   int flags = minfo.flags;
@@ -98,7 +98,6 @@ void get_face(uint localId, modelinfo minfo, float cameraYaw, float cameraPitch,
     vec4 thisrvB = rotate_vertex(vec4(thisB.pos, 0), orientation);
     vec4 thisrvC = rotate_vertex(vec4(thisC.pos, 0), orientation);
 
-    int thisPriority = (thisA.ahsl >> 16) & 0xff;// all vertices on the face have the same priority
     int thisDistance = face_distance(thisrvA.xyz, thisrvB.xyz, thisrvC.xyz, cameraYaw, cameraPitch);
 
     o1.pos = thisrvA.xyz;
@@ -110,7 +109,6 @@ void get_face(uint localId, modelinfo minfo, float cameraYaw, float cameraPitch,
     o3.pos = thisrvC.xyz;
     o3.ahsl = thisC.ahsl;
 
-    prio = thisPriority;
     dis = thisDistance;
   } else {
     o1.pos = vec3(0);
@@ -121,17 +119,29 @@ void get_face(uint localId, modelinfo minfo, float cameraYaw, float cameraPitch,
 
     o3.pos = vec3(0);
     o3.ahsl = 0;
-    prio = 0;
     dis = 0;
   }
 }
 
-void add_face_prio_distance(uint localId, modelinfo minfo, Vertex thisrvA, Vertex thisrvB, Vertex thisrvC, int thisPriority, int thisDistance, ivec4 pos) {
+void add_face_prio_distance(uint localId, modelinfo minfo, Vertex thisrvA, Vertex thisrvB, Vertex thisrvC, int thisDistance, ivec4 pos) {
   if (localId < minfo.size) {
+    int thisPriority = (thisrvA.ahsl >> 16) & 0xff;// all vertices on the face have the same priority
     // if the face is not culled, it is calculated into priority distance averages
     if (face_visible(thisrvA.pos, thisrvB.pos, thisrvC.pos, pos)) {
-      atomicAdd(totalNum[thisPriority], 1);
-      atomicAdd(totalDistance[thisPriority], thisDistance);
+      if (thisPriority == 1 || thisPriority == 2) {
+        atomicAdd(totalNum12, 1);
+        atomicAdd(totalDistance12, thisDistance);
+      }
+      else if (thisPriority == 3 || thisPriority == 4) {
+        atomicAdd(totalNum34, 1);
+        atomicAdd(totalDistance34, thisDistance);
+      }
+      else if (thisPriority == 6 || thisPriority == 8) {
+        atomicAdd(totalNum68, 1);
+        atomicAdd(totalDistance68, thisDistance);
+      }
+      //atomicAdd(totalNum[thisPriority], 1);
+      //atomicAdd(totalDistance[thisPriority], thisDistance);
 
       // calculate minimum distance to any face of priority 10 for positioning the 11 faces later
       if (thisPriority == 10) {
@@ -141,29 +151,21 @@ void add_face_prio_distance(uint localId, modelinfo minfo, Vertex thisrvA, Verte
   }
 }
 
-int map_face_priority(uint localId, modelinfo minfo, int thisPriority, int thisDistance, out int prio) {
+int map_face_priority(uint localId, modelinfo minfo, int thisDistance, Vertex thisrvA, out int prio) {
   int size = minfo.size;
 
   // Compute average distances for 0/2, 3/4, and 6/8
 
   if (localId < size) {
-    int avg1 = 0;
-    int avg2 = 0;
-    int avg3 = 0;
+    int thisPriority = (thisrvA.ahsl >> 16) & 0xff;// all vertices on the face have the same priority
+    float avg1 = float(totalDistance12) / float(totalNum12);
+    float avg2 = float(totalDistance34) / float(totalNum34);
+    float avg3 = float(totalDistance68) / float(totalNum68);
+    avg1 *= float(totalNum12 > 0);
+    avg2 *= float(totalNum34 > 0);
+    avg3 *= float(totalNum68 > 0);
 
-    if (totalNum[1] > 0 || totalNum[2] > 0) {
-      avg1 = (totalDistance[1] + totalDistance[2]) / (totalNum[1] + totalNum[2]);
-    }
-
-    if (totalNum[3] > 0 || totalNum[4] > 0) {
-      avg2 = (totalDistance[3] + totalDistance[4]) / (totalNum[3] + totalNum[4]);
-    }
-
-    if (totalNum[6] > 0 || totalNum[8] > 0) {
-      avg3 = (totalDistance[6] + totalDistance[8]) / (totalNum[6] + totalNum[8]);
-    }
-
-    int adjPrio = priority_map(thisPriority, thisDistance, min10, avg1, avg2, avg3);
+    int adjPrio = priority_map(thisPriority, thisDistance, min10, int(avg1), int(avg2), int(avg3));
     int prioIdx = atomicAdd(totalMappedNum[adjPrio], 1);
 
     prio = adjPrio;
@@ -237,7 +239,7 @@ void undoVanillaShading(inout int hsl, vec3 unrotatedNormal) {
 
 void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, int thisDistance,
                               Vertex thisrvA, Vertex thisrvB, Vertex thisrvC,
-                              out int myOffset, out int thisRenderPri) {
+                              out int myOffset) {
   int size = minfo.size;
 
   if (localId < size) {
@@ -263,8 +265,6 @@ void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, i
         ++myOffset;
       }
     }
-
-    thisRenderPri = renderPris[localId];
   }
 }
 
@@ -288,7 +288,7 @@ void output_vertices_and_flags(uint localId, modelinfo minfo, Vertex thisrvA, Ve
   }
 }
 
-void gather_texture_attribute(uint localId, modelinfo minfo, out vec4 texA, out vec4 texB, out vec4 texC) {
+void gather_texture_attribute(uint localId, modelinfo minfo, uint vertexIndex, out vec4 tex) {
   int size = minfo.size;
 
   if (localId < size) {
@@ -299,57 +299,40 @@ void gather_texture_attribute(uint localId, modelinfo minfo, out vec4 texA, out 
     int hillskew = (flags >> BIT_HILLSKEW) & 1;
     vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
 
-    // Read the other vertex attributes for localId
-    texA = vec4(0);
-    texB = vec4(0);
-    texC = vec4(0);
-
+    tex = vec4(0);
     if (toffset >= 0)
     {
       if (flags >= 0) {
-        texA = temptexb[toffset + localId * 3];
-        texB = temptexb[toffset + localId * 3 + 1];
-        texC = temptexb[toffset + localId * 3 + 2];
+        tex = temptexb[toffset + localId * 3 + vertexIndex];
       } else {
-        texA = texb[toffset + localId * 3];
-        texB = texb[toffset + localId * 3 + 1];
-        texC = texb[toffset + localId * 3 + 2];
+        tex = texb[toffset + localId * 3 + vertexIndex];
       }
 
       // swizzle from (tex,x,y,z) to (x,y,z,tex) for rotate and hillskew
-      texA = texA.yzwx;
-      texB = texB.yzwx;
-      texC = texC.yzwx;
+      tex = tex.yzwx;
       // rotate
-      texA = rotate_vertex(texA, orientation);
-      texB = rotate_vertex(texB, orientation);
-      texC = rotate_vertex(texC, orientation);
+      tex = rotate_vertex(tex, orientation);
       // position
-      texA += pos;
-      texB += pos;
-      texC += pos;
+      tex += pos;
       // hillskew
-      texA = hillskew_vertexf(texA, hillskew, minfo.y, plane);
-      texB = hillskew_vertexf(texB, hillskew, minfo.y, plane);
-      texC = hillskew_vertexf(texC, hillskew, minfo.y, plane);
+      tex = hillskew_vertexf(tex, hillskew, minfo.y, plane);
+      tex = tex.wxyz; // back to (tex,x,y,z)
     }
   }
 }
 
-void output_uvs(uint localId, modelinfo minfo, vec4 texA, vec4 texB, vec4 texC) {
+void output_uv(uint localId, modelinfo minfo, uint vertexIndex, vec4 tex) {
   int size = minfo.size;
   vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
   if (localId < size) {
     int myOffset = int(localId);
     int outOffset = minfo.idx;
 
-    uvout[outOffset + myOffset * 3] = texA.wxyz;
-    uvout[outOffset + myOffset * 3 + 1] = texB.wxyz;
-    uvout[outOffset + myOffset * 3 + 2] = texC.wxyz;
+    uvout[outOffset + myOffset * 3 + vertexIndex] = tex;
   }
 }
 
-void gather_normal_attribute(uint localId, modelinfo minfo, out vec4 normA, out vec4 normB, out vec4 normC) {
+void gather_normal_attribute(uint localId, modelinfo minfo, uint vertexIndex, out vec4 norm) {
   int size = minfo.size;
 
   if (localId < size) {
@@ -361,36 +344,25 @@ void gather_normal_attribute(uint localId, modelinfo minfo, out vec4 normA, out 
 
     if (flags < 0)
     {
-      normA = normal[offset + localId * 3    ];
-      normB = normal[offset + localId * 3 + 1];
-      normC = normal[offset + localId * 3 + 2];
+      norm = normal[offset + localId * 3 + vertexIndex];
     }
     else
     {
-      normA = tempnormal[offset + localId * 3    ];
-      normB = tempnormal[offset + localId * 3 + 1];
-      normC = tempnormal[offset + localId * 3 + 2];
+      norm = tempnormal[offset + localId * 3 + vertexIndex];
     }
 
-    normA = rotate_vertex(normA, orientation);
-    normB = rotate_vertex(normB, orientation);
-    normC = rotate_vertex(normC, orientation);
-
-    normA = hillskew_vertexf(normA, hillskew, minfo.y, plane);
-    normB = hillskew_vertexf(normB, hillskew, minfo.y, plane);
-    normC = hillskew_vertexf(normC, hillskew, minfo.y, plane);
+    norm = rotate_vertex(norm, orientation);
+    norm = hillskew_vertexf(norm, hillskew, minfo.y, plane);
   }
 }
 
-void output_normals(uint localId, modelinfo minfo, vec4 normA, vec4 normB, vec4 normC) {
+void output_normal(uint localId, modelinfo minfo, uint vertexIndex, vec4 norm) {
   int size = minfo.size;
   vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
   if (localId < size) {
     int myOffset = int(localId);
     int outOffset = minfo.idx;
 
-    normalout[outOffset + myOffset * 3]     = normA;
-    normalout[outOffset + myOffset * 3 + 1] = normB;
-    normalout[outOffset + myOffset * 3 + 2] = normC;
+    normalout[outOffset + myOffset * 3 + vertexIndex] = norm;
   }
 }

--- a/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
@@ -235,7 +235,90 @@ void undoVanillaShading(inout int hsl, vec3 unrotatedNormal) {
   hsl = (hsl & ~0x7F) | lightness;
 }
 
-void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, int thisDistance, Vertex thisrvA, Vertex thisrvB, Vertex thisrvC, out int myOffset, out int thisRenderPri) {
+void gather_texture_attribute(uint localId, modelinfo minfo, out vec4 texA, out vec4 texB, out vec4 texC) {
+  int size = minfo.size;
+
+  if (localId < size) {
+    int toffset = minfo.toffset;
+    int flags = minfo.flags;
+    int orientation = flags & 0x7ff;
+    int plane = (flags >> BIT_ZHEIGHT) & 3;
+    int hillskew = (flags >> BIT_HILLSKEW) & 1;
+    vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
+
+    // Read the other vertex attributes for localId
+    texA = vec4(0);
+    texB = vec4(0);
+    texC = vec4(0);
+
+    if (toffset >= 0)
+    {
+      if (flags >= 0) {
+        texA = temptexb[toffset + localId * 3];
+        texB = temptexb[toffset + localId * 3 + 1];
+        texC = temptexb[toffset + localId * 3 + 2];
+      } else {
+        texA = texb[toffset + localId * 3];
+        texB = texb[toffset + localId * 3 + 1];
+        texC = texb[toffset + localId * 3 + 2];
+      }
+
+      // swizzle from (tex,x,y,z) to (x,y,z,tex) for rotate and hillskew
+      texA = texA.yzwx;
+      texB = texB.yzwx;
+      texC = texC.yzwx;
+      // rotate
+      texA = rotate_vertex(texA, orientation);
+      texB = rotate_vertex(texB, orientation);
+      texC = rotate_vertex(texC, orientation);
+      // position
+      texA += pos;
+      texB += pos;
+      texC += pos;
+      // hillskew
+      texA = hillskew_vertexf(texA, hillskew, minfo.y, plane);
+      texB = hillskew_vertexf(texB, hillskew, minfo.y, plane);
+      texC = hillskew_vertexf(texC, hillskew, minfo.y, plane);
+    }
+  }
+}
+
+void gather_normal_attribute(uint localId, modelinfo minfo, out vec4 normA, out vec4 normB, out vec4 normC) {
+  int size = minfo.size;
+
+  if (localId < size) {
+    int offset = minfo.offset;
+    int flags = minfo.flags;
+    int orientation = flags & 0x7ff;
+    int plane = (flags >> BIT_ZHEIGHT) & 3;
+    int hillskew = (flags >> BIT_HILLSKEW) & 1;
+
+    if (flags < 0)
+    {
+      normA = normal[offset + localId * 3    ];
+      normB = normal[offset + localId * 3 + 1];
+      normC = normal[offset + localId * 3 + 2];
+    }
+    else
+    {
+      normA = tempnormal[offset + localId * 3    ];
+      normB = tempnormal[offset + localId * 3 + 1];
+      normC = tempnormal[offset + localId * 3 + 2];
+    }
+
+    normA = rotate_vertex(normA, orientation);
+    normB = rotate_vertex(normB, orientation);
+    normC = rotate_vertex(normC, orientation);
+
+    normA = hillskew_vertexf(normA, hillskew, minfo.y, plane);
+    normB = hillskew_vertexf(normB, hillskew, minfo.y, plane);
+    normC = hillskew_vertexf(normC, hillskew, minfo.y, plane);
+  }
+}
+
+void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, int thisDistance,
+                              Vertex thisrvA, Vertex thisrvB, Vertex thisrvC,
+                              out int myOffset, out int thisRenderPri) {
   int size = minfo.size;
 
   if (localId < size) {
@@ -264,10 +347,6 @@ void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, i
 
     thisRenderPri = renderPris[localId];
 /*
-    vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
-    vec4 vertA = vec4(thisrvA.pos, 0) + pos;
-    vec4 vertB = vec4(thisrvB.pos, 0) + pos;
-    vec4 vertC = vec4(thisrvC.pos, 0) + pos;
     vec4 normA, normB, normC;
     ivec4 flagsA, flagsB, flagsC;
 
@@ -366,7 +445,10 @@ void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, i
   }
 }
 
-void position_and_output(uint localId, modelinfo minfo, Vertex thisrvA, Vertex thisrvB, Vertex thisrvC) {
+void position_and_output(uint localId, modelinfo minfo,
+                         Vertex thisrvA, Vertex thisrvB, Vertex thisrvC,
+                         vec4 texA, vec4 texB, vec4 texC,
+                         vec4 normA, vec4 normB, vec4 normC) {
   int size = minfo.size;
   vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
   if (localId < size) {
@@ -389,8 +471,16 @@ void position_and_output(uint localId, modelinfo minfo, Vertex thisrvA, Vertex t
     vout[outOffset + myOffset * 3 + 1] = Vertex(vertB.xyz, thisrvB.ahsl);
     vout[outOffset + myOffset * 3 + 2] = Vertex(vertC.xyz, thisrvC.ahsl);
 
-    uvout[outOffset + myOffset * 3] = vec4(0);
-    uvout[outOffset + myOffset * 3 + 1] = vec4(0);
-    uvout[outOffset + myOffset * 3 + 2] = vec4(0);
+    uvout[outOffset + myOffset * 3] = texA.wxyz;
+    uvout[outOffset + myOffset * 3 + 1] = texB.wxyz;
+    uvout[outOffset + myOffset * 3 + 2] = texC.wxyz;
+
+    flagsout[outOffset + myOffset * 3]     = minfo.exFlags;
+    flagsout[outOffset + myOffset * 3 + 1] = minfo.exFlags;
+    flagsout[outOffset + myOffset * 3 + 2] = minfo.exFlags;
+
+    normalout[outOffset + myOffset * 3]     = normA;
+    normalout[outOffset + myOffset * 3 + 1] = normB;
+    normalout[outOffset + myOffset * 3 + 2] = normC;
   }
 }

--- a/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
@@ -319,6 +319,9 @@ void gather_texture_attribute(uint localId, modelinfo minfo, uint vertexIndex, o
       tex = tex.wxyz; // back to (tex,x,y,z)
     }
   }
+  else {
+    tex = vec4(0);
+  }
 }
 
 void output_uv(uint localId, modelinfo minfo, uint vertexIndex, vec4 tex) {
@@ -353,6 +356,9 @@ void gather_normal_attribute(uint localId, modelinfo minfo, uint vertexIndex, ou
 
     norm = rotate_vertex(norm, orientation);
     norm = hillskew_vertexf(norm, hillskew, minfo.y, plane);
+  }
+  else {
+    norm = vec4(0);
   }
 }
 

--- a/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
@@ -235,6 +235,59 @@ void undoVanillaShading(inout int hsl, vec3 unrotatedNormal) {
   hsl = (hsl & ~0x7F) | lightness;
 }
 
+void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, int thisDistance,
+                              Vertex thisrvA, Vertex thisrvB, Vertex thisrvC,
+                              out int myOffset, out int thisRenderPri) {
+  int size = minfo.size;
+
+  if (localId < size) {
+    int outOffset = minfo.idx;
+    int toffset = minfo.toffset;
+    int flags = minfo.flags;
+    int offset = minfo.offset;
+
+    // we only have to order faces against others of the same priority
+    const int priorityOffset = count_prio_offset(thisPriority);
+    const int numOfPriority = totalMappedNum[thisPriority];
+    const int start = priorityOffset;                // index of first face with this priority
+    const int end = priorityOffset + numOfPriority;  // index of last face with this priority
+    const int renderPriority = thisDistance << 16 | int(~localId & 0xffffu);
+    myOffset = priorityOffset;
+    int orientation = flags & 0x7ff;
+    int plane = (flags >> BIT_ZHEIGHT) & 3;
+    int hillskew = (flags >> BIT_HILLSKEW) & 1;
+
+    // calculate position this face will be in
+    for (int i = start; i < end; ++i) {
+      if (renderPriority < renderPris[i]) {
+        ++myOffset;
+      }
+    }
+
+    thisRenderPri = renderPris[localId];
+  }
+}
+
+void output_vertices_and_flags(uint localId, modelinfo minfo, Vertex thisrvA, Vertex thisrvB, Vertex thisrvC) {
+  int size = minfo.size;
+  vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
+  if (localId < size) {
+    vec4 vertA = vec4(thisrvA.pos, 0) + pos;
+    vec4 vertB = vec4(thisrvB.pos, 0) + pos;
+    vec4 vertC = vec4(thisrvC.pos, 0) + pos;
+
+    int myOffset = int(localId);
+    int outOffset = minfo.idx;
+    vout[outOffset + myOffset * 3]     = Vertex(vertA.xyz, thisrvA.ahsl);
+    vout[outOffset + myOffset * 3 + 1] = Vertex(vertB.xyz, thisrvB.ahsl);
+    vout[outOffset + myOffset * 3 + 2] = Vertex(vertC.xyz, thisrvC.ahsl);
+
+    flagsout[outOffset + myOffset * 3]     = minfo.exFlags;
+    flagsout[outOffset + myOffset * 3 + 1] = minfo.exFlags;
+    flagsout[outOffset + myOffset * 3 + 2] = minfo.exFlags;
+  }
+}
+
 void gather_texture_attribute(uint localId, modelinfo minfo, out vec4 texA, out vec4 texB, out vec4 texC) {
   int size = minfo.size;
 
@@ -283,6 +336,19 @@ void gather_texture_attribute(uint localId, modelinfo minfo, out vec4 texA, out 
   }
 }
 
+void output_uvs(uint localId, modelinfo minfo, vec4 texA, vec4 texB, vec4 texC) {
+  int size = minfo.size;
+  vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
+  if (localId < size) {
+    int myOffset = int(localId);
+    int outOffset = minfo.idx;
+
+    uvout[outOffset + myOffset * 3] = texA.wxyz;
+    uvout[outOffset + myOffset * 3 + 1] = texB.wxyz;
+    uvout[outOffset + myOffset * 3 + 2] = texC.wxyz;
+  }
+}
+
 void gather_normal_attribute(uint localId, modelinfo minfo, out vec4 normA, out vec4 normB, out vec4 normC) {
   int size = minfo.size;
 
@@ -316,168 +382,12 @@ void gather_normal_attribute(uint localId, modelinfo minfo, out vec4 normA, out 
   }
 }
 
-void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, int thisDistance,
-                              Vertex thisrvA, Vertex thisrvB, Vertex thisrvC,
-                              out int myOffset, out int thisRenderPri) {
-  int size = minfo.size;
-
-  if (localId < size) {
-    int outOffset = minfo.idx;
-    int toffset = minfo.toffset;
-    int flags = minfo.flags;
-    int offset = minfo.offset;
-
-    // we only have to order faces against others of the same priority
-    const int priorityOffset = count_prio_offset(thisPriority);
-    const int numOfPriority = totalMappedNum[thisPriority];
-    const int start = priorityOffset;                // index of first face with this priority
-    const int end = priorityOffset + numOfPriority;  // index of last face with this priority
-    const int renderPriority = thisDistance << 16 | int(~localId & 0xffffu);
-    myOffset = priorityOffset;
-    int orientation = flags & 0x7ff;
-    int plane = (flags >> BIT_ZHEIGHT) & 3;
-    int hillskew = (flags >> BIT_HILLSKEW) & 1;
-
-    // calculate position this face will be in
-    for (int i = start; i < end; ++i) {
-      if (renderPriority < renderPris[i]) {
-        ++myOffset;
-      }
-    }
-
-    thisRenderPri = renderPris[localId];
-/*
-    vec4 normA, normB, normC;
-    ivec4 flagsA, flagsB, flagsC;
-
-    if (flags < 0)
-    {
-        normA = normal[offset + localId * 3    ];
-        normB = normal[offset + localId * 3 + 1];
-        normC = normal[offset + localId * 3 + 2];
-
-        flagsA = flagsin[offset + localId * 3    ];
-        flagsB = flagsin[offset + localId * 3 + 1];
-        flagsC = flagsin[offset + localId * 3 + 2];
-    }
-    else
-    {
-        normA = tempnormal[offset + localId * 3    ];
-        normB = tempnormal[offset + localId * 3 + 1];
-        normC = tempnormal[offset + localId * 3 + 2];
-
-        flagsA = tempflags[offset + localId * 3    ];
-        flagsB = tempflags[offset + localId * 3 + 1];
-        flagsC = tempflags[offset + localId * 3 + 2];
-    }
-//
-//    // undo vanilla lighting
-//    undoVanillaShading(thisrvA.ahsl, normA.xyz);
-//    undoVanillaShading(thisrvB.ahsl, normB.xyz);
-//    undoVanillaShading(thisrvC.ahsl, normC.xyz);
-
-    normA = rotate_vertex(normA, orientation);
-    normB = rotate_vertex(normB, orientation);
-    normC = rotate_vertex(normC, orientation);
-
-    // apply hillskew
-    vertA = hillskew_vertexf(vertA, hillskew, minfo.y, plane);
-    vertB = hillskew_vertexf(vertB, hillskew, minfo.y, plane);
-    vertC = hillskew_vertexf(vertC, hillskew, minfo.y, plane);
-
-    normA = hillskew_vertexf(normA, hillskew, minfo.y, plane);
-    normB = hillskew_vertexf(normB, hillskew, minfo.y, plane);
-    normC = hillskew_vertexf(normC, hillskew, minfo.y, plane);
-
-    normalout[outOffset + myOffset * 3]     = normA;
-    normalout[outOffset + myOffset * 3 + 1] = normB;
-    normalout[outOffset + myOffset * 3 + 2] = normC;
-
-    flagsout[outOffset + myOffset * 3]     = minfo.exFlags;
-    flagsout[outOffset + myOffset * 3 + 1] = minfo.exFlags;
-    flagsout[outOffset + myOffset * 3 + 2] = minfo.exFlags;
-
-    // write to out buffer
-    vout[outOffset + myOffset * 3]     = Vertex(vertA.xyz, thisrvA.ahsl);
-    vout[outOffset + myOffset * 3 + 1] = Vertex(vertB.xyz, thisrvB.ahsl);
-    vout[outOffset + myOffset * 3 + 2] = Vertex(vertC.xyz, thisrvC.ahsl);
-
-    if (toffset < 0)
-    {
-      uvout[outOffset + myOffset * 3] = vec4(0);
-      uvout[outOffset + myOffset * 3 + 1] = vec4(0);
-      uvout[outOffset + myOffset * 3 + 2] = vec4(0);
-    }
-    else
-    {
-      vec4 texA, texB, texC;
-
-      if (flags >= 0) {
-        texA = temptexb[toffset + localId * 3];
-        texB = temptexb[toffset + localId * 3 + 1];
-        texC = temptexb[toffset + localId * 3 + 2];
-      } else {
-        texA = texb[toffset + localId * 3];
-        texB = texb[toffset + localId * 3 + 1];
-        texC = texb[toffset + localId * 3 + 2];
-      }
-
-      // swizzle from (tex,x,y,z) to (x,y,z,tex) for rotate and hillskew
-      texA = texA.yzwx;
-      texB = texB.yzwx;
-      texC = texC.yzwx;
-      // rotate
-      texA = rotate_vertex(texA, orientation);
-      texB = rotate_vertex(texB, orientation);
-      texC = rotate_vertex(texC, orientation);
-      // position
-      texA += pos;
-      texB += pos;
-      texC += pos;
-      // hillskew
-      texA = hillskew_vertexf(texA, hillskew, minfo.y, plane);
-      texB = hillskew_vertexf(texB, hillskew, minfo.y, plane);
-      texC = hillskew_vertexf(texC, hillskew, minfo.y, plane);
-      uvout[outOffset + myOffset * 3] = texA.wxyz;
-      uvout[outOffset + myOffset * 3 + 1] = texB.wxyz;
-      uvout[outOffset + myOffset * 3 + 2] = texC.wxyz;
-    }*/
-  }
-}
-
-void position_and_output(uint localId, modelinfo minfo,
-                         Vertex thisrvA, Vertex thisrvB, Vertex thisrvC,
-                         vec4 texA, vec4 texB, vec4 texC,
-                         vec4 normA, vec4 normB, vec4 normC) {
+void output_normals(uint localId, modelinfo minfo, vec4 normA, vec4 normB, vec4 normC) {
   int size = minfo.size;
   vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
   if (localId < size) {
-    vec4 vertA = vec4(thisrvA.pos, 0) + pos;
-    vec4 vertB = vec4(thisrvB.pos, 0) + pos;
-    vec4 vertC = vec4(thisrvC.pos, 0) + pos;
-
-    int flags = minfo.flags;
-    int orientation = flags & 0x7ff;
-    int plane = (flags >> BIT_ZHEIGHT) & 3;
-    int hillskew = (flags >> BIT_HILLSKEW) & 1;
-
-    //vertA = hillskew_vertexf(vertA, hillskew, minfo.y, plane);
-    //vertB = hillskew_vertexf(vertB, hillskew, minfo.y, plane);
-    //vertC = hillskew_vertexf(vertC, hillskew, minfo.y, plane);
-
     int myOffset = int(localId);
     int outOffset = minfo.idx;
-    vout[outOffset + myOffset * 3]     = Vertex(vertA.xyz, thisrvA.ahsl);
-    vout[outOffset + myOffset * 3 + 1] = Vertex(vertB.xyz, thisrvB.ahsl);
-    vout[outOffset + myOffset * 3 + 2] = Vertex(vertC.xyz, thisrvC.ahsl);
-
-    uvout[outOffset + myOffset * 3] = texA.wxyz;
-    uvout[outOffset + myOffset * 3 + 1] = texB.wxyz;
-    uvout[outOffset + myOffset * 3 + 2] = texC.wxyz;
-
-    flagsout[outOffset + myOffset * 3]     = minfo.exFlags;
-    flagsout[outOffset + myOffset * 3 + 1] = minfo.exFlags;
-    flagsout[outOffset + myOffset * 3 + 2] = minfo.exFlags;
 
     normalout[outOffset + myOffset * 3]     = normA;
     normalout[outOffset + myOffset * 3 + 1] = normB;

--- a/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
+++ b/src/main/resources/com/gpuExtended/shaders/glsl/priority_render.glsl
@@ -235,7 +235,7 @@ void undoVanillaShading(inout int hsl, vec3 unrotatedNormal) {
   hsl = (hsl & ~0x7F) | lightness;
 }
 
-void sort_and_insert(uint localId, modelinfo minfo, int thisPriority, int thisDistance, Vertex thisrvA, Vertex thisrvB, Vertex thisrvC) {
+void calculate_output_offsets(uint localId, modelinfo minfo, int thisPriority, int thisDistance, Vertex thisrvA, Vertex thisrvB, Vertex thisrvC, out int myOffset, out int thisRenderPri) {
   int size = minfo.size;
 
   if (localId < size) {
@@ -250,7 +250,7 @@ void sort_and_insert(uint localId, modelinfo minfo, int thisPriority, int thisDi
     const int start = priorityOffset;                // index of first face with this priority
     const int end = priorityOffset + numOfPriority;  // index of last face with this priority
     const int renderPriority = thisDistance << 16 | int(~localId & 0xffffu);
-    int myOffset = priorityOffset;
+    myOffset = priorityOffset;
     int orientation = flags & 0x7ff;
     int plane = (flags >> BIT_ZHEIGHT) & 3;
     int hillskew = (flags >> BIT_HILLSKEW) & 1;
@@ -262,6 +262,8 @@ void sort_and_insert(uint localId, modelinfo minfo, int thisPriority, int thisDi
       }
     }
 
+    thisRenderPri = renderPris[localId];
+/*
     vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
     vec4 vertA = vec4(thisrvA.pos, 0) + pos;
     vec4 vertB = vec4(thisrvB.pos, 0) + pos;
@@ -360,6 +362,35 @@ void sort_and_insert(uint localId, modelinfo minfo, int thisPriority, int thisDi
       uvout[outOffset + myOffset * 3] = texA.wxyz;
       uvout[outOffset + myOffset * 3 + 1] = texB.wxyz;
       uvout[outOffset + myOffset * 3 + 2] = texC.wxyz;
-    }
+    }*/
+  }
+}
+
+void position_and_output(uint localId, modelinfo minfo, Vertex thisrvA, Vertex thisrvB, Vertex thisrvC) {
+  int size = minfo.size;
+  vec4 pos = vec4(minfo.x, minfo.y, minfo.z, 0);
+  if (localId < size) {
+    vec4 vertA = vec4(thisrvA.pos, 0) + pos;
+    vec4 vertB = vec4(thisrvB.pos, 0) + pos;
+    vec4 vertC = vec4(thisrvC.pos, 0) + pos;
+
+    int flags = minfo.flags;
+    int orientation = flags & 0x7ff;
+    int plane = (flags >> BIT_ZHEIGHT) & 3;
+    int hillskew = (flags >> BIT_HILLSKEW) & 1;
+
+    //vertA = hillskew_vertexf(vertA, hillskew, minfo.y, plane);
+    //vertB = hillskew_vertexf(vertB, hillskew, minfo.y, plane);
+    //vertC = hillskew_vertexf(vertC, hillskew, minfo.y, plane);
+
+    int myOffset = int(localId);
+    int outOffset = minfo.idx;
+    vout[outOffset + myOffset * 3]     = Vertex(vertA.xyz, thisrvA.ahsl);
+    vout[outOffset + myOffset * 3 + 1] = Vertex(vertB.xyz, thisrvB.ahsl);
+    vout[outOffset + myOffset * 3 + 2] = Vertex(vertC.xyz, thisrvC.ahsl);
+
+    uvout[outOffset + myOffset * 3] = vec4(0);
+    uvout[outOffset + myOffset * 3 + 1] = vec4(0);
+    uvout[outOffset + myOffset * 3 + 2] = vec4(0);
   }
 }


### PR DESCRIPTION
Complete weirdo code, but it brings my compute shader execution time from 7.596ms to 3.38ms in prif all the way zoomed out.

For anyone else who happens upon this:
The idea is that each thread in the compute shader has to read the vertices at their index, and then after finding their sorted index they scatter vertices into the output buffer at `buffer[sortedIndex]` (pseudocode)
So effectively
```
vert = inputBuffer[i]
sortedIndex = ...;
outputBuffer[sortedIndex] = vert;
```
The initial read is "coalesced", meaning basically that all threads read memory pretty much linearly, so when a single cache line of say 64 bytes is pulled in for a single read of only 4 bytes, other threads don't have to go all the way to global memory.

The write is not coalesced though. 
But it could be, since *some* thread in the thread group has read the vertex we need to output for this thread.

So the idea is: shuffle the vertices we read linearly in shared memory such that
```
vert = inputBuffer[i]
sortedIndex = ...;
vertFromOtherThread = shuffle(sortedIndex, ...);
outputBuffer[i] = vertFromOtherThread;
```

Note that now we're reading from [i] and writing to [i] which makes the GPU very happy.


This also includes a change to split the model buffers more finely, so instead of small models and large models, we have models for each size starting at 64 up to MAX_TRIANGLES. This only saved about ~0.3ms on my card.